### PR TITLE
Fix broken A&P logo filename

### DIFF
--- a/sponsors.html
+++ b/sponsors.html
@@ -211,7 +211,7 @@
 					<img src="images/harwin_logo.png">
 				</a>
 				<a href="http://www.braider.com/" target="_blank">
-					<img src="images/A&P_logo.png">
+					<img src="images/A&P_Logo.png">
 				</a>
 			</div>
 			<div class="bronzeInlineWide">


### PR DESCRIPTION
The file is named `A&P_Logo.png`, but `sponsors.html` had `A&P_logo.png` (note the capitalization). This works fine on Windows because NTFS filenames aren't case-sensitive, but it breaks on whatever server is hosting our page, which is presumably not NTFS.