### PR TITLE
Update internal URLs to no longer show .html

### DIFF
--- a/awards.html
+++ b/awards.html
@@ -14,18 +14,18 @@
 		<div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
-				<li><a href="competition.html">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="competition">COMPETITION</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div>
 			<div id="awards_cover"></div>

--- a/competition.html
+++ b/competition.html
@@ -14,18 +14,18 @@
 		<div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
-				<li><a href="competition.html">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="competition">COMPETITION</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div>
 

--- a/contact.html
+++ b/contact.html
@@ -14,18 +14,18 @@
 		<div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
-				<li><a href="competition.html">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>					
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="competition">COMPETITION</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>					
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div>
 

--- a/contact.html
+++ b/contact.html
@@ -23,7 +23,7 @@
 				<li><a href="sponsors">SPONSORS</a>
 				<li><a href="rockets">ROCKETS</a>
 				<li><a href="team">TEAM</a>
-				<li><a href="awards">AWARDS</a>		
+				<li><a href="awards">AWARDS</a>
 				<li><a href="events">EVENTS</a>
 				<li><a href="contact">CONTACT</a>
 			</ul>

--- a/contact.html
+++ b/contact.html
@@ -23,7 +23,7 @@
 				<li><a href="sponsors">SPONSORS</a>
 				<li><a href="rockets">ROCKETS</a>
 				<li><a href="team">TEAM</a>
-				<li><a href="awards">AWARDS</a>					
+				<li><a href="awards">AWARDS</a>		
 				<li><a href="events">EVENTS</a>
 				<li><a href="contact">CONTACT</a>
 			</ul>

--- a/eridani.html
+++ b/eridani.html
@@ -15,18 +15,18 @@
         <div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
-				<li><a href="competition.html">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="competition">COMPETITION</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
         </div>
 

--- a/events.html
+++ b/events.html
@@ -14,18 +14,18 @@
 		<div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
-				<li><a href="competition.html">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="competition">COMPETITION</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div>
 

--- a/index.html
+++ b/index.html
@@ -15,18 +15,18 @@
 		<div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
-				<li><a href="competition.html">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="competition">COMPETITION</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div>
 		<div class="cover-photo"></div>
@@ -46,20 +46,20 @@
 		</div>
 		<div class="links col-md-12">
 			<div class="col-md-4">
-				<a href="rockets.html">
+				<a href="rockets">
 					<img src="images/rockets_cover.jpg">
 				</a>
 				<h1 class="content-title">
-					<a href="rockets.html">ROCKETS</a>
+					<a href="rockets">ROCKETS</a>
 				</h1>
 				<p class="content-text">Take a look at what we've worked on in the past.</p>
 			</div>
 			<div class="col-md-4">
-				<a href="sponsors.html">
+				<a href="sponsors">
 					<img src="images/sponsors_cover.jpg"/>
 				</a>
 				<h1 class="content-title">
-					<a href="sponsors.html">SPONSORS</a>
+					<a href="sponsors">SPONSORS</a>
 				</h1>
 				<p class="content-text">We are grateful to our sponsors. Please take a look at who they are.</p>
 			</div>

--- a/rockets.html
+++ b/rockets.html
@@ -14,25 +14,25 @@
 		<div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
-				<li><a href="competition.html">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="competition">COMPETITION</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div> 
 
 		<div class="page-wrap">
 			<div class="box__wrapper">
 				<div class="box col-md-4">
-						<a href="sots.html">
+						<a href="sots">
 							<div class="box__inner" id="sots">
 								<h1 class="title">SHARK OF THE SKY</h1>
 								<h1 class="title">2019</h1>
@@ -40,7 +40,7 @@
 						</a>
 					</div>
 				<div class="box col-md-4">
-					<a href="uxo.html">
+					<a href="uxo">
 						<div class="box__inner" id="uxo">
 							<h1 class="title">UNEXPLODED ORDNANCE</h1>
 							<h1 class="title">2018</h1>
@@ -48,7 +48,7 @@
 					</a>
 				</div>
 				<div class="box col-md-4">
-					<a href="vidar3.html">
+					<a href="vidar3">
 						<div class="box__inner" id="vidar3">
 							<h1 class="title">VIDAR III</h1>
 							<h1 class="title">2016/2017</h1>
@@ -56,7 +56,7 @@
 					</a>
 				</div>
 				<div class="box col-md-4">
-					<a href="vidar2.html">
+					<a href="vidar2">
 						<div class="box__inner" id="vidar2">
 							<h1 class="title">VIDAR II</h1>
 							<h1 class="title">2015</h1>
@@ -64,7 +64,7 @@
 					</a>
 				</div>
 				<div class="box col-md-4">
-					<a href="vidar.html">
+					<a href="vidar">
 						<div class="box__inner" id="vidar">
 							<h1 class="title">VIDAR</h1>
 							<h1 class="title">2014</h1>
@@ -72,7 +72,7 @@
 					</a>
 				</div>
 				<div class="box col-md-4">
-					<a href="silverbrant.html">
+					<a href="silverbrant">
 						<div class="box__inner" id="silverbrant">
 							<h1 class="title">SILVER BRANT</h1>
 							<h1 class="title">2013</h1>
@@ -80,7 +80,7 @@
 					</a>
 				</div>
 				<div class="box col-md-4">
-					<a href="eridani.html">
+					<a href="eridani">
 						<div class="box__inner" id="eridani">
 							<h1 class="title">ERIDANI</h1>
 							<h1 class="title">2012</h1>
@@ -88,7 +88,7 @@
 					</a>
 				</div>
 				<div class="box col-md-4">
-					<a href="wrt1.html">
+					<a href="wrt1">
 						<div class="box__inner" id="wrt1">
 							<h1 class="title">WRT 1</h1>
 							<h1 class="title">2011</h1>

--- a/silverbrant.html
+++ b/silverbrant.html
@@ -15,18 +15,18 @@
         <div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
-				<li><a href="competition.html">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="competition">COMPETITION</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div>
 

--- a/sots.html
+++ b/sots.html
@@ -14,18 +14,18 @@
 		<div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
 				<li><a href="competition">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div> 
 

--- a/sponsors.html
+++ b/sponsors.html
@@ -14,18 +14,18 @@
 		<div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 				<img class="banner__logo" src="images/banner_logo.png" />
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
-				<li><a href="competition.html">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="competition">COMPETITION</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 	</div>
 

--- a/team.html
+++ b/team.html
@@ -14,18 +14,18 @@
 		<div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
-				<li><a href="competition.html">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="competition">COMPETITION</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div>
 

--- a/uxo.html
+++ b/uxo.html
@@ -14,18 +14,18 @@
 		<div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
 				<li><a href="competition">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div> 
 

--- a/vidar.html
+++ b/vidar.html
@@ -24,7 +24,7 @@
 				<li><a href="sponsors">SPONSORS</a>
 				<li><a href="rockets">ROCKETS</a>
 				<li><a href="team">TEAM</a>
-				<li><a href="awards">AWARDS</a>	
+				<li><a href="awards">AWARDS</a>
 				<li><a href="events">EVENTS</a>
 				<li><a href="contact">CONTACT</a>
 			</ul>

--- a/vidar.html
+++ b/vidar.html
@@ -15,18 +15,18 @@
         <div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
-				<li><a href="competition.html">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>	
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="competition">COMPETITION</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>	
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div>
 

--- a/vidar2.html
+++ b/vidar2.html
@@ -15,18 +15,18 @@
 		<div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
 				<li><a href="competition">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div> 
 

--- a/vidar3.html
+++ b/vidar3.html
@@ -14,18 +14,18 @@
 		<div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
 				<li><a href="competition">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div> 
 

--- a/wrt1.html
+++ b/wrt1.html
@@ -24,7 +24,7 @@
 				<li><a href="sponsors">SPONSORS</a>
 				<li><a href="rockets">ROCKETS</a>
 				<li><a href="team">TEAM</a>
-				<li><a href="awards">AWARDS</a>					
+				<li><a href="awards">AWARDS</a>
 				<li><a href="events">EVENTS</a>
 				<li><a href="contact">CONTACT</a>
 			</ul>

--- a/wrt1.html
+++ b/wrt1.html
@@ -15,18 +15,18 @@
         <div class="banner">
 			<!--- missing </li> tags to remove space between inline block elements -->
 			<ul class="pull-left nav--left">
-				<a href="index.html">
+				<a href="/">
 					<img class="banner__logo" src="images/banner_logo.png"/>
 				</a>
 			</ul>
 			<ul class="pull-right nav--right">
-				<li><a href="competition.html">COMPETITION</a>
-				<li><a href="sponsors.html">SPONSORS</a>
-				<li><a href="rockets.html">ROCKETS</a>
-				<li><a href="team.html">TEAM</a>
-				<li><a href="awards.html">AWARDS</a>					
-				<li><a href="events.html">EVENTS</a>
-				<li><a href="contact.html">CONTACT</a>
+				<li><a href="competition">COMPETITION</a>
+				<li><a href="sponsors">SPONSORS</a>
+				<li><a href="rockets">ROCKETS</a>
+				<li><a href="team">TEAM</a>
+				<li><a href="awards">AWARDS</a>					
+				<li><a href="events">EVENTS</a>
+				<li><a href="contact">CONTACT</a>
 			</ul>
 		</div>
 


### PR DESCRIPTION
Changed all the banner URLs so that clicking to another page doesn't
show a URL with a ".html" at the end, eg
 "waterloorocketry.com/competition.html" would now be
 "waterloorocketry.com/competition".

 Also fixed index.html links to show just "waterloorocketry.com"
 rather than "waterloorocketry.com/index.html".