### PR TITLE
Fix resizing of team page so profiles wrap nicely

### DIFF
--- a/css/team.css
+++ b/css/team.css
@@ -7,6 +7,8 @@
 }
 
 .members__info {
+	display: block;
+	float: left;
 	padding-top: 1.5rem;
 	padding-left: 1.5rem;
 	padding-right: 1rem;

--- a/css/team.css
+++ b/css/team.css
@@ -15,11 +15,14 @@
 	padding-bottom: 1.5rem;
 }
 
-.box__wrapper {
-	padding-top: 5.2rem;
+.container-fluid {
+	display: block;
+	clear: both;
+	padding-top: 1rem;
 	padding-left: 2rem;
 	padding-right: 2rem;
 	padding-bottom: 1.5rem;
+	margin: 0;
 }
 
 .box__outer{

--- a/team.html
+++ b/team.html
@@ -29,344 +29,344 @@
             </ul>
         </div>
         <div id="members_cover"></div>
-        <div class="members__info col-md-12">
+        <div class="members__info">
             <h1 class="content-title">TEAM</h1>
             <p class="content-text">
                 Waterloo Rocketry is a multidisciplinary team with members from Mechanical, Mechatronics, Electrical, Computer, Chemical, Systems Design, Nanotechnology, and Civil Engineering, as well as from the Science and Mathematics faculties. Our team members have diverse backgrounds and skillsets ranging from firmware and systems programming to structural and thermal analysis, and encompassing everything in between.
             </p>
         </div>
         <div class="box__wrapper">
-            <div class="col-md-2 box__outer" id="jacob">
+            <div class="col-sm-2 box__outer" id="jacob">
                 <div class="box__inner">
                     <h1>Jacob Deery</h1>
                     <h2>Team Lead</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="tom">
+            <div class="col-sm-2 box__outer" id="tom">
                 <div class="box__inner">
                     <h1>Tom Cojocar</h1>
                     <h2>Propulsion/Team Lead</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="shirley">
+            <div class="col-sm-2 box__outer" id="shirley">
                 <div class="box__inner">
                     <h1>Shirley Kong</h1>
                     <h2>Airframe/Team Lead</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="doris">
+            <div class="col-sm-2 box__outer" id="doris">
                 <div class="box__inner">
                     <h1>Doris Jiang</h1>
                     <h2>Safety Captain</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="hussein">
+            <div class="col-sm-2 box__outer" id="hussein">
                 <div class="box__inner">
                     <h1>Hussein Saafan</h1>
                     <h2>Safety Captain</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="alex">
+            <div class="col-sm-2 box__outer" id="alex">
                 <div class="box__inner">
                     <h1>Alex Mihaila</h1>
                     <h2>Electrical</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="vithusan">
+            <div class="col-sm-2 box__outer" id="vithusan">
                 <div class="box__inner">
                     <h1>Vithusan Rajkumar</h1>
                     <h2>Senior Propulsion Member</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="aaron">
+            <div class="col-sm-2 box__outer" id="aaron">
                 <div class="box__inner">
                     <h1>Aaron Morrison</h1>
                     <h2>Electrical</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="adam">
+            <div class="col-sm-2 box__outer" id="adam">
                 <div class="box__inner">
                     <h1>Adam Paul</h1>
                     <h2>Electrical</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="stefan">
+            <div class="col-sm-2 box__outer" id="stefan">
                 <div class="box__inner">
                     <h1>Stefan Martin</h1>
                     <h2>Senior Propulsion Member</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="riley">
+            <div class="col-sm-2 box__outer" id="riley">
                 <div class="box__inner">
                     <h1>Riley Holierhoek</h1>
                     <h2>Media</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="aidan">
+            <div class="col-sm-2 box__outer" id="aidan">
                 <div class="box__inner">
                     <h1>Aidan Ha</h1>
                     <h2>Electrical</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="edward">
+            <div class="col-sm-2 box__outer" id="edward">
                 <div class="box__inner">
                     <h1>Edward Yang</h1>
                     <h2>DAQ, WUSA Liasion</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="veronica">
+            <div class="col-sm-2 box__outer" id="veronica">
                 <div class="box__inner">
                     <h1>Veronica Barry</h1>
                     <h2>Senior Member</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="delaney">
+            <div class="col-sm-2 box__outer" id="delaney">
                 <div class="box__inner">
                     <h1>Delaney Dyment</h1>
                     <h2>Finance Lead/Payload</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="aaronl">
+            <div class="col-sm-2 box__outer" id="aaronl">
                 <div class="box__inner">
                     <h1>Aaron Leszkowiat</h1>
                     <h2>Propulsion Lead</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="alexander">
+            <div class="col-sm-2 box__outer" id="alexander">
                 <div class="box__inner">
                     <h1>Alexander Kitaev</h1>
                     <h2>Electrical</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="kyle">
+            <div class="col-sm-2 box__outer" id="kyle">
                 <div class="box__inner">
                     <h1>Kyle Tam</h1>
                     <h2>Payload Lead</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="ryan">
+            <div class="col-sm-2 box__outer" id="ryan">
                 <div class="box__inner">
                     <h1>Ryan Tan</h1>
                     <h2>Member</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="roman">
+            <div class="col-sm-2 box__outer" id="roman">
                 <div class="box__inner">
                     <h1>Roman Kobets</h1>
                     <h2>Recovery Lead</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="zach">
+            <div class="col-sm-2 box__outer" id="zach">
                 <div class="box__inner">
                     <h1>Zachariah Mears</h1>
                     <h2>Electrical Lead</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="matti">
+            <div class="col-sm-2 box__outer" id="matti">
                 <div class="box__inner">
                     <h1>Matti Gencher</h1>
                     <h2>Member</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="teresa">
+            <div class="col-sm-2 box__outer" id="teresa">
                 <div class="box__inner">
                     <h1>Teresa Tang</h1>
                     <h2>DAQ</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="dawson">
+            <div class="col-sm-2 box__outer" id="dawson">
                 <div class="box__inner">
                     <h1>Dawson Kletke</h1>
                     <h2>Telemetry Lead/Recovery</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="zhenbo">
+            <div class="col-sm-2 box__outer" id="zhenbo">
                 <div class="box__inner">
                     <h1>Zhen Bo Bian</h1>
                     <h2>Payload Member</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="kaveeshan">
+            <div class="col-sm-2 box__outer" id="kaveeshan">
                 <div class="box__inner">
                     <h1>Kaveeshan Thurairajah</h1>
                     <h2>Fill Disconnect</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="ben">
+            <div class="col-sm-2 box__outer" id="ben">
                 <div class="box__inner">
                     <h1>Ben Dunk</h1>
                     <h2>Member</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="joanna">
+            <div class="col-sm-2 box__outer" id="joanna">
                 <div class="box__inner">
                     <h1>Joanna Diao</h1>
                     <h2>Electrical/Payload</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="abm">
+            <div class="col-sm-2 box__outer" id="abm">
                 <div class="box__inner">
                     <h1>ABM Hussien</h1>
                     <h2>Propulsion/Recovery</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="hamza">
+            <div class="col-sm-2 box__outer" id="hamza">
                 <div class="box__inner">
                     <h1>Hamza Abuabah</h1>
                     <h2>Member</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="waleed">
+            <div class="col-sm-2 box__outer" id="waleed">
                 <div class="box__inner">
                     <h1>Waleed Parwez</h1>
                     <h2>Propulsion/Payload</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="jared">
+            <div class="col-sm-2 box__outer" id="jared">
                 <div class="box__inner">
                     <h1>Jared Watson</h1>
                     <h2>Electrical</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="lana">
+            <div class="col-sm-2 box__outer" id="lana">
                 <div class="box__inner">
                     <h1>Lana Tomlin</h1>
                     <h2>Electrical</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="ronald">
+            <div class="col-sm-2 box__outer" id="ronald">
                 <div class="box__inner">
                     <h1>Ronald Trang</h1>
                     <h2>Propulsion Member</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="sophie">
+            <div class="col-sm-2 box__outer" id="sophie">
                 <div class="box__inner">
                     <h1>Sophie Hillcoat</h1>
                     <h2>Member</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="francis">
+            <div class="col-sm-2 box__outer" id="francis">
                 <div class="box__inner">
                     <h1>Francis Yao</h1>
                     <h2>Aiframe/Payload</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="chamath">
+            <div class="col-sm-2 box__outer" id="chamath">
                 <div class="box__inner">
                     <h1>Chamath Wijesekera</h1>
                     <h2>Electrical</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="sophier">
+            <div class="col-sm-2 box__outer" id="sophier">
                 <div class="box__inner">
                     <h1>Sophie Rahn</h1>
                     <h2>Member</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="kaelan">
+            <div class="col-sm-2 box__outer" id="kaelan">
                 <div class="box__inner">
                     <h1>Kaelan Moffett-Steinke</h1>
                     <h2>Electrical</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="tommy">
+            <div class="col-sm-2 box__outer" id="tommy">
                 <div class="box__inner">
                     <h1>Tommy Huang</h1>
                     <h2>Electrical</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="wendi">
+            <div class="col-sm-2 box__outer" id="wendi">
                 <div class="box__inner">
                     <h1>Wendi Yu</h1>
                     <h2>Electrical</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__outer" id="nadine">
+            <div class="col-sm-2 box__outer" id="nadine">
                 <div class="box__inner">
                     <h1>Nadine Arar</h1>
                     <h2>Member</h2>
                 </div>
             </div>
         </div>
-        <div class="members__info col-md-12">
+        <div class="members__info">
             <h1 class="content-title">ALUMNI</h1>
             <p class="content-text">
                 Our success would not have been possible without the efforts of countless alumni. Their dedication, leadership, and mentorship have paved the way for the current team, and while it would be impossible to list everyone who has played a part in the team's history, we would like to acknowledge those who we can.
             </p>
         </div>
         <div class="box__wrapper">
-            <div class="col-md-2 box__alum__outer" id="nick">
+            <div class="col-sm-2 box__alum__outer" id="nick">
                 <div class="box__alum__inner">
                     <h1>Nick Christopher</h1>
                     <h2>MASc '20; Mech '18</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__alum__outer" id="justin">
+            <div class="col-sm-2 box__alum__outer" id="justin">
                 <div class="box__alum__inner">
                     <h1>Justin Robinson</h1>
                     <h2>Mech '19</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__alum__outer" id="miranda">
+            <div class="col-sm-2 box__alum__outer" id="miranda">
                 <div class="box__alum__inner">
                     <h1>Miranda Daly</h1>
                     <h2>Mech '19</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__alum__outer" id="hilbert">
+            <div class="col-sm-2 box__alum__outer" id="hilbert">
                 <div class="box__alum__inner">
                     <h1>Hilbert Li</h1>
                     <h2>Mech '18</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__alum__outer" id="robin">
+            <div class="col-sm-2 box__alum__outer" id="robin">
                 <div class="box__alum__inner">
                     <h1>Robin Liu</h1>
                     <h2>Mech '18</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__alum__outer" id="nina">
+            <div class="col-sm-2 box__alum__outer" id="nina">
                 <div class="box__alum__inner">
                     <h1>Nina Kornilovsky</h1>
                     <h2>Civil '18</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__alum__outer" id="david">
+            <div class="col-sm-2 box__alum__outer" id="david">
                 <div class="box__alum__inner">
                     <h1>David Ng</h1>
                     <h2>Mech '18</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__alum__outer" id="chris">
+            <div class="col-sm-2 box__alum__outer" id="chris">
                 <div class="box__alum__inner">
                     <h1>Chris Virtue</h1>
                     <h2>Tron '18</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__alum__outer" id="yash">
+            <div class="col-sm-2 box__alum__outer" id="yash">
                 <div class="box__alum__inner">
                     <h1>Yash Sewlani</h1>
                     <h2>Mech '17</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__alum__outer" id="ivan">
+            <div class="col-sm-2 box__alum__outer" id="ivan">
                 <div class="box__alum__inner">
                     <h1>Ivan Baranov</h1>
                     <h2>Comp '17</h2>
                 </div>
             </div>
-            <div class="col-md-2 box__alum__outer" id="yiqing">
+            <div class="col-sm-2 box__alum__outer" id="yiqing">
                 <div class="box__alum__inner">
                     <h1>Yiqing Wang</h1>
                     <h2>Mech '16</h2>
                 </div>
             </div>
         </div>
-        <div class="col-md-12">
+        <div class="col-sm-12">
             <br>
         </div>
-        <div class="footer col-md-12">
+        <div class="footer col-sm-12">
             <div class="footer__container">
                 <a href="https://www.facebook.com/WaterlooRocketry/">
                 <img src="images/icon_fb.png">

--- a/team.html
+++ b/team.html
@@ -32,10 +32,10 @@
         <div class="members__info">
             <h1 class="content-title">TEAM</h1>
             <p class="content-text">
-                Waterloo Rocketry is a multidisciplinary team with members from Mechanical, Mechatronics, Electrical, Computer, Chemical, Systems Design, Nanotechnology, and Civil Engineering, as well as from the Science and Mathematics faculties. Our team members have diverse backgrounds and skillsets ranging from firmware and systems programming to structural and thermal analysis, and encompassing everything in between.
+                Waterloo Rocketry is a multidisciplinary team with members from Mechanical, Mechatronics, Electrical, Computer, Chemical, Systems Design, Nanotechnology, Software, and Civil Engineering, as well as from the Science and Mathematics faculties. Our team members have diverse backgrounds and skillsets ranging from firmware and systems programming to structural and thermal analysis, and encompassing everything in between.
             </p>
         </div>
-        <div class="box__wrapper">
+        <div class="container-fluid">
             <div class="col-sm-2 box__outer" id="jacob">
                 <div class="box__inner">
                     <h1>Jacob Deery</h1>
@@ -295,7 +295,7 @@
                 Our success would not have been possible without the efforts of countless alumni. Their dedication, leadership, and mentorship have paved the way for the current team, and while it would be impossible to list everyone who has played a part in the team's history, we would like to acknowledge those who we can.
             </p>
         </div>
-        <div class="box__wrapper">
+        <div class="container-fluid">
             <div class="col-sm-2 box__alum__outer" id="nick">
                 <div class="box__alum__inner">
                     <h1>Nick Christopher</h1>
@@ -362,9 +362,6 @@
                     <h2>Mech '16</h2>
                 </div>
             </div>
-        </div>
-        <div class="col-sm-12">
-            <br>
         </div>
         <div class="footer col-sm-12">
             <div class="footer__container">


### PR DESCRIPTION
Changed bootstrap grid size to allow the number of profiles per row
to scale nicely based on screen width, instead of immediately changing
to only one per row - replaced md columns with sm ones