### PR TITLE
Update sponsors

### DIFF
--- a/sponsors.html
+++ b/sponsors.html
@@ -190,12 +190,6 @@
                 <a href="https://uwaterloo.ca/sandford-fleming-foundation/" target="_blank">
                 <img src="images/SFF_Logo.png">
                 </a>
-                <a href="https://www.digi.com/" target="_blank">
-                <img src="images/digi_logo.png">
-                </a>
-                <a href="https://www.robotshop.com/" target="_blank">
-                <img src="images/robotshop.png">
-                </a>
                 <a href="https://eljentechnology.com/" target="_blank">
                 <img src="images/eljen_logo.png">
                 </a>
@@ -314,6 +308,12 @@
                 </a>
                 <a href="https://www.dutton-lainson.com/" target="_blank">
                 <img src="images/dutton_lainson.png">
+                </a>
+                <a href="https://www.digi.com/" target="_blank">
+                <img src="images/digi_logo.png">
+                </a>
+                <a href="https://www.robotshop.com/" target="_blank">
+                <img src="images/robotshop.png">
                 </a>
             </div>
         </div>


### PR DESCRIPTION
Moved Digi and RobotShop from bronze to previous sponsors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/website/111)
<!-- Reviewable:end -->
