### PR TITLE
correct typo for subsystems page link

### DIFF
--- a/join.html
+++ b/join.html
@@ -122,7 +122,7 @@
                             <li>Representing the team at high school and university outreach events</li>
                         </ul>
                         <br>
-                        Check out our <a href="subsytems">subsytems page</a> for more information. Each subsystem has a "currently working on"
+                        Check out our <a href="subsystems">subsytems page</a> for more information. Each subsystem has a "currently working on"
                         section that can provide a better glimpse of available work.
                     </div>
                 </div>


### PR DESCRIPTION
Missed a typo on an href, quick fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/website/117)
<!-- Reviewable:end -->
