### PR TITLE
Update "About Us" blurb on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
                 <div class="content__about col-md-6">
                     <h1 class="content-title">ABOUT US</h1>
                     <p class="content-text">
-                        Waterloo Rocketry is a student design team composed primarily of undergraduate students at the University of Waterloo in Waterloo, Ontario. We currently have around 20 members from a variety of engineering disciplines. We design, build, and launch rockets to a target altitude of 10,000' at the Intercollegiate Rocket Engineering Competition each June at Spaceport America, New Mexico. It is our mission to excel through innovative design, disciplined engineering, and precision fabrication.
+                        Waterloo Rocketry is a student design team from the University of Waterloo in Waterloo, Ontario. We currently have around 50 members, primarily undergraduate students in engineering, science, and mathematics. We design, build, and launch rockets to a target altitude of 30,000' at the Intercollegiate Rocket Engineering Competition each June at Spaceport America, New Mexico. Our team's primary objective is to provide students with hands-on learning opportunities in research, design, analysis, fabrication, and testing throughout the entire engineering design cycle.
                     </p>
                 </div>
                 <div class="content__join col-md-6">


### PR DESCRIPTION
- We have more than 20 members and they're not just in engineering
- We launch to 30k
- Our primary objective is learning opportunities

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/website/120)
<!-- Reviewable:end -->
