### PR TITLE
Rename sponsors__container and sponsors__header classes

### DIFF
--- a/css/sponsors.css
+++ b/css/sponsors.css
@@ -11,19 +11,19 @@
 	padding-bottom: 1.5rem;
 }
 
-.sponsors__header {
+.tier_header {
 	text-align: center;
 	margin-top: 1rem;
 	margin-bottom: 1rem;
 }
 
-.sponsors__header .line {
+.tier_header .line {
 	margin-left: 1rem;
 	margin-right: 1rem;
 }
 
 
-.sponsors__container {
+.logo_container {
 	padding: 3rem;
 	padding-top: 0rem;
 	text-align: center;

--- a/sponsors.html
+++ b/sponsors.html
@@ -43,13 +43,13 @@
             </div>
         </div>
         <div class="line"></div>
-        <div class="sponsors__header col-md-12">
+        <div class="tier_header col-md-12">
             <h1 class="content-title">PLATINUM SPONSORS</h1>
             <div class="line"></div>
         </div>
         <div class="container-fluid platinum">
             <div class="row justify-content-center">
-                <div class="sponsors__container  col-md-6 col-md-offset-3">
+                <div class="logo_container  col-md-6 col-md-offset-3">
                     <a href="http://www.steinindustriesinc.com/" target="_blank">
                     <img src="images/stein_logo.png" />
                     </a>
@@ -63,7 +63,7 @@
                 </div>
             </div>
             <div class="row justify-content-center">
-                <div class="sponsors__container col-md-6">
+                <div class="logo_container col-md-6">
                     <a href="https://www.ansys.com/" target="_blank">
                     <img src="images/ANSYS_Logo.png"/>
                     </a>
@@ -75,7 +75,7 @@
                         Engineering simulation is our sole focus. For more than 45 years, we have consistently advanced this technology to meet evolving customer needs. ANSYS develops, markets and supports engineering simulation software used to predict how product designs will behave in real-world environments.
                     </p>
                 </div>
-                <div class="sponsors__container col-md-6">
+                <div class="logo_container col-md-6">
                     <a href="http://www.harwin.com/" target="_blank">
                     <img src="images/harwin_logo.png">
                     </a>
@@ -93,7 +93,7 @@
                 </div>
             </div>
             <div class="row justify-content-center">
-                <div class="sponsors__container  col-md-6">
+                <div class="logo_container  col-md-6">
                     <a href="https://uwaterloo.ca/engineering-endowment-foundation/" target="_blank">
                     <img src="images/WEEF_Logo_yellow.png" />
                     </a>
@@ -105,7 +105,7 @@
                         The premise of WEEF is simple. WEEF collects donations and puts them into a fund. The interest earned on the fund is spent each year on undergraduate laboratory equipment, student projects, computer upgrades and academic tools/teaching facilities. The principal portion of the fund is never spent which allows the interest each year to grow, hence "The Gift That Keeps On Giving". As of 2018, the WEEF fund has a principal of over $15,000,000. WEEF is proud to support undergraduate engineering across all departments at the University of Waterloo.
                     </p>
                 </div>
-                <div class="sponsors__container  col-md-6">
+                <div class="logo_container  col-md-6">
                     <a href="https://uwaterloo.ca/engineering/" target="_blank">
                     <img src="images/Waterloo_ENG_Faculty_Logo_rgb.png" />
                     </a>
@@ -119,7 +119,7 @@
                 </div>
             </div>
             <div class="row justify-content-center">
-                <div class="sponsors__container  col-md-6">
+                <div class="logo_container  col-md-6">
                     <a href="https://keysight.com" target="_blank">
                     <img src="images/Keysight.png" />
                     </a>
@@ -135,7 +135,7 @@
                         Keysight customers are visionaries and innovators. They have achieved breakthroughs that advance technology, like covering the far reaches of the world with wideband satellite communications, driving data rates higher in 5G and beyond, ensuring solid connectivity and outstanding experience for wireless and IoT devices, realizing new levels of cloud computing, enabling the connected car, and even making rockets that go higher with more intelligence. 25 of the top 25 Technology Companies use Keysight.
                     </p>
                 </div>
-                <div class="sponsors__container  col-md-6">
+                <div class="logo_container  col-md-6">
                     <a href="https://www.solidworks.com/" target="_blank">
                     <img src="images/solidworks_logo.png" />
                     </a>
@@ -153,12 +153,12 @@
                 </div>
             </div>
         </div>
-        <div class="sponsors__header col-md-12">
+        <div class="tier_header col-md-12">
             <h1 class="content-title">GOLD SPONSORS</h1>
             <div class="line"></div>
         </div>
         <div class="col-md-12 gold">
-            <div class="sponsors__container col-md-6 col-md-offset-3">
+            <div class="logo_container col-md-6 col-md-offset-3">
                 <a href="https://uwaterloo.ca/math-endowment-fund/" target="_blank">
                 <img src="images/mef_logo.png" />
                 </a>
@@ -167,7 +167,7 @@
                 </p>
             </div>
         </div>
-        <div class="sponsors__header col-md-12">
+        <div class="tier_header col-md-12">
             <h1 class="content-title">SILVER SPONSORS</h1>
             <div class="line"></div>
         </div>
@@ -183,12 +183,12 @@
                 </a>
             </div>
         </div>
-        <div class="sponsors__header col-md-12">
+        <div class="tier_header col-md-12">
             <h1 class="content-title">BRONZE SPONSORS</h1>
             <div class="line"></div>
             <br>
         </div>
-        <div class="sponsors__container col-md-12">
+        <div class="logo_container col-md-12">
             <div class="bronzeInlineWide" style = "text-align: center;">
                 <a href="http://www.swagelok.com/en" target="_blank">
                 <img src="images/swagelok_logo.png">
@@ -246,11 +246,11 @@
                 </a>
             </div>
         </div>
-        <div class="sponsors__header col-md-12">
+        <div class="tier_header col-md-12">
             <h1 class="content-title">PREVIOUS SPONSORS</h1>
             <div class="line"></div>
         </div>
-        <div class="sponsors__container previous col-md-12 bronzeInline">
+        <div class="logo_container previous col-md-12 bronzeInline">
             <div>
                 <a href="http://www.ni.com/en-us.html" target="_blank">
                 <img src="images/ni_logo.JPG" />


### PR DESCRIPTION
Make the sponsor logos visible again.

I didn't rename `sponsor_cover` because I couldn't think of a better name. Suggestions welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/website/133)
<!-- Reviewable:end -->
